### PR TITLE
Add the ability to have a custom InputDecoration

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -73,7 +73,7 @@ class _MyHomePageState extends State<MyHomePage> {
               ),
               DateTimeFormField(
                 key: Key("DEC"),
-                initialValue: widget.initialDateTime,
+                initialValue: widget.initialDateTime.add(Duration(days: 1)),
                 label: "Date Time With Decoartion",
                 inputDecoration: InputDecoration(icon: Icon(Icons.calendar_today)),
                 validator: (DateTime dateTime) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,6 +60,7 @@ class _MyHomePageState extends State<MyHomePage> {
           child: Column(
             children: <Widget>[
               DateTimeFormField(
+                key: Key("BASE"),
                 initialValue: widget.initialDateTime,
                 label: "Date Time",
                 validator: (DateTime dateTime) {
@@ -70,6 +71,19 @@ class _MyHomePageState extends State<MyHomePage> {
                 },
                 onSaved: (DateTime dateTime) => _dateTime = dateTime,
               ),
+              DateTimeFormField(
+                key: Key("DEC"),
+                initialValue: widget.initialDateTime,
+                label: "Date Time With Decoartion",
+                inputDecoration: InputDecoration(icon: Icon(Icons.calendar_today)),
+                validator: (DateTime dateTime) {
+                  if (dateTime == null) {
+                    return "Date Time Required";
+                  }
+                  return null;
+                },
+                onSaved: (DateTime dateTime) => _dateTime = dateTime,
+              ),              
               Spacer(),
               Padding(
                 padding: const EdgeInsets.all(16.0),

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -10,21 +10,28 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:example/main.dart';
 
+
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('Test Calendar Pop-Up', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    expect(find.byKey(Key("BASE")), findsOneWidget);
+ 
+    // Tap the DateFormField and trigger a pop-up.
+    await tester.press(find.byKey(Key("BASE")));
+    await tester.pumpAndSettle();
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+  });
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+  testWidgets('Test Calendar with Custom InputDecoration',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(MyApp());
+    
+    // Find the decorated DateFormField
+    expect(find.byKey(Key("DEC")), findsOneWidget);
+
+    // Ensure the icon is visible
+    expect(find.byIcon(Icons.calendar_today), findsOneWidget);
   });
 }

--- a/lib/flutter_datetime_formfield.dart
+++ b/lib/flutter_datetime_formfield.dart
@@ -45,7 +45,7 @@ class DateTimeFormField extends StatelessWidget {
 
   /// Create a DateTimeFormField.
   /// The [onlyDate] and [onlyTime] arguments can not be set to true at the same time.
-  DateTimeFormField({
+  DateTimeFormField({Key key,
     @required DateTime initialValue,
     @required String label,
     DateFormat formatter,
@@ -69,7 +69,8 @@ class DateTimeFormField extends StatelessWidget {
                     : DateFormat("EE, MMM d, yyyy h:mma"))),
         firstDate = firstDate ?? DateTime(1970),
         lastDate = lastDate ?? DateTime(2100),
-        inputDecoration = inputDecoration ?? InputDecoration(labelText: label);
+        inputDecoration = inputDecoration ?? InputDecoration(labelText: label),
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/flutter_datetime_formfield.dart
+++ b/lib/flutter_datetime_formfield.dart
@@ -9,27 +9,39 @@ import 'dart:io' show Platform;
 class DateTimeFormField extends StatelessWidget {
   /// The initial date time, default value is 'DateTime.now()'.
   final DateTime initialValue;
+
   /// Save value function of form field.
   final FormFieldSetter<DateTime> onSaved;
+
   /// Validate function of form field.
   final FormFieldValidator<DateTime> validator;
+
   /// Whether validate every time, default value is false.
   final bool autovalidate;
   final bool enabled;
+
   /// The label of form field, default value is 'Date Time'.
   final String label;
+
   /// The format of displaying date time in form field, default value is 'DateFormat("EE, MMM d, yyyy h:mma")' in date and time mode,
   /// 'DateFormat("EEE, MMM d, yyyy")' in date only mode,
   /// 'DateFormat("h:mm a") in time only mode.
   final DateFormat formatter;
+
   /// Only show and edit date, default value is false.
   final bool onlyDate;
+
   /// Only show and edit time, default value is false. [onlyDate] and [onlyTime] cannot be set to true at the same time.
   final bool onlyTime;
+
   /// The first date time of picking, default value is 'DateTime(1970)'.
   final DateTime firstDate;
+
   /// The last date time of picking, default value is 'DateTime(2100)'.
   final DateTime lastDate;
+
+  /// Use a custom InputDecoration to allow features like a leading icon
+  final InputDecoration inputDecoration;
 
   /// Create a DateTimeFormField.
   /// The [onlyDate] and [onlyTime] arguments can not be set to true at the same time.
@@ -45,6 +57,7 @@ class DateTimeFormField extends StatelessWidget {
     this.onlyTime: false,
     DateTime firstDate,
     DateTime lastDate,
+    InputDecoration inputDecoration,
   })  : assert(!onlyDate || !onlyTime),
         initialValue = initialValue ?? DateTime.now(),
         label = label ?? "Date Time",
@@ -55,7 +68,8 @@ class DateTimeFormField extends StatelessWidget {
                     ? DateFormat("h:mm a")
                     : DateFormat("EE, MMM d, yyyy h:mma"))),
         firstDate = firstDate ?? DateTime(1970),
-        lastDate = lastDate ?? DateTime(2100);
+        lastDate = lastDate ?? DateTime(2100),
+        inputDecoration = inputDecoration ?? InputDecoration(labelText: label);
 
   @override
   Widget build(BuildContext context) {
@@ -68,10 +82,7 @@ class DateTimeFormField extends StatelessWidget {
       builder: (FormFieldState state) {
         return InkWell(
           child: InputDecorator(
-            decoration: InputDecoration(
-              labelText: label,
-              errorText: state.errorText,
-            ),
+            decoration: inputDecoration.copyWith(errorText: state.errorText, labelText: label),
             child: Text(formatter.format(state.value)),
           ),
           onTap: () async {
@@ -96,7 +107,8 @@ class DateTimeFormField extends StatelessWidget {
                       height: MediaQuery.of(context).size.height / 4,
                       child: CupertinoDatePicker(
                         mode: CupertinoDatePickerMode.date,
-                        onDateTimeChanged:(DateTime dateTime) => state.didChange(dateTime),
+                        onDateTimeChanged: (DateTime dateTime) =>
+                            state.didChange(dateTime),
                         initialDateTime: state.value,
                         minimumYear: firstDate.year,
                         maximumYear: lastDate.year,
@@ -128,7 +140,8 @@ class DateTimeFormField extends StatelessWidget {
                       height: MediaQuery.of(context).size.height / 4,
                       child: CupertinoDatePicker(
                         mode: CupertinoDatePickerMode.time,
-                        onDateTimeChanged:(DateTime dateTime) => state.didChange(dateTime),
+                        onDateTimeChanged: (DateTime dateTime) =>
+                            state.didChange(dateTime),
                         initialDateTime: state.value,
                         use24hFormat: false,
                         minuteInterval: 1,
@@ -168,7 +181,8 @@ class DateTimeFormField extends StatelessWidget {
                       height: MediaQuery.of(context).size.height / 4,
                       child: CupertinoDatePicker(
                         mode: CupertinoDatePickerMode.dateAndTime,
-                        onDateTimeChanged:(DateTime dateTime) => state.didChange(dateTime),
+                        onDateTimeChanged: (DateTime dateTime) =>
+                            state.didChange(dateTime),
                         initialDateTime: state.value,
                         use24hFormat: false,
                         minuteInterval: 1,

--- a/test/flutter_datetime_formfield_test.dart
+++ b/test/flutter_datetime_formfield_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 
@@ -18,5 +19,21 @@ void main() {
 
     expect(labelFinder, findsOneWidget);
     expect(textFieldFinder, findsOneWidget);
+  });
+
+  testWidgets('Test Calendar with Custom InputDecoration',
+      (WidgetTester tester) async {
+    DateTime dateTime = DateTime.now();
+    //String textField = DateFormat("EE, MMM d, yyyy h:mma").format(dateTime);
+    
+    await tester.pumpWidget(MyApp(
+      initialDateTime: dateTime,
+    ));
+    
+    // Find the decorated DateFormField
+    expect(find.byKey(Key("DEC")), findsOneWidget);
+
+    // Ensure the icon is visible
+    expect(find.byIcon(Icons.calendar_today), findsOneWidget);
   });
 }


### PR DESCRIPTION
Allow the widget to support a custom InputDecoration. For example, I wanted to show a leading icon.

I also added the following:
Key
InputDecoration

If no InputDecoration, then just create with labelText and errorText as before, else use the custom InputDecoration

TESTS:
Added a test to find the DateFormField by key and press it.

Added a test to find the icon in the InputDecoration